### PR TITLE
Removed type attribute from link and script tags

### DIFF
--- a/tasks/grunt-htmlrefs.js
+++ b/tasks/grunt-htmlrefs.js
@@ -21,10 +21,10 @@ module.exports = function (grunt) {
 	var regend = /<!--\s*endbuild\s*-->/;
 
 	// <script> template
-	var scriptTemplate = '<script type="text/javascript" src="<%= dest %>"></script>';
+	var scriptTemplate = '<script src="<%= dest %>"></script>';
 
 	// stylesheet template
-	var stylesheetTemplate = '<link rel="stylesheet" type="text/css" href="<%= dest %>">';
+	var stylesheetTemplate = '<link rel="stylesheet" href="<%= dest %>">';
 
 	grunt.registerMultiTask('htmlrefs', "Replaces (or removes) references to non-optimized scripts or stylesheets on HTML files", function () {
 		var params = (this.data.options || {});


### PR DESCRIPTION
Hi, thanks for a great plugin. In HTML5 type attributes are no longer required on link and script tags, so making a pull request for this.

/Chiel
