### PR TITLE
update inlineCSS to work with options parameter/ template evaluation

### DIFF
--- a/tasks/grunt-htmlrefs.js
+++ b/tasks/grunt-htmlrefs.js
@@ -71,8 +71,10 @@ module.exports = function (grunt) {
 			},
 			inlinecss : function (block) {
 				var indent = (block.raw[0].match(/^\s*/) || [])[0];
+					block.dest = grunt.template.process(block.dest, {data: block});
 				var lines = grunt.file.read(block.dest).replace(/\r\n/g, '\n').split(/\n/).map(function(l) {return indent + l});
-				return indent + grunt.template.process(inlineCSSTemplate, {data: {dest:lines}});
+				var options = _.extend(block, {dest:lines});
+				return indent + grunt.template.process(inlineCSSTemplate, {data: options});
 			},
 			include : function (block, lf, includes) {
 				// let's see if we have that include listed


### PR DESCRIPTION
bugfix so that the following code works

```
<!-- ref:inlinecss /static/css/compiled.<%= buildNumber %>.css -->
```
